### PR TITLE
chore: add dependencies for OAuth2 and Spring Security

### DIFF
--- a/.idea/libraries/Maven__com_github_stephenc_jcip_jcip_annotations_1_0_1.xml
+++ b/.idea/libraries/Maven__com_github_stephenc_jcip_jcip_annotations_1_0_1.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.github.stephenc.jcip:jcip-annotations:1.0-1">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/stephenc/jcip/jcip-annotations/1.0-1/jcip-annotations-1.0-1.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/stephenc/jcip/jcip-annotations/1.0-1/jcip-annotations-1.0-1-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/stephenc/jcip/jcip-annotations/1.0-1/jcip-annotations-1.0-1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_nimbusds_content_type_2_1.xml
+++ b/.idea/libraries/Maven__com_nimbusds_content_type_2_1.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.nimbusds:content-type:2.1">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/content-type/2.1/content-type-2.1.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/content-type/2.1/content-type-2.1-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/content-type/2.1/content-type-2.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_nimbusds_lang_tag_1_4_4.xml
+++ b/.idea/libraries/Maven__com_nimbusds_lang_tag_1_4_4.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.nimbusds:lang-tag:1.4.4">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/lang-tag/1.4.4/lang-tag-1.4.4.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/lang-tag/1.4.4/lang-tag-1.4.4-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/lang-tag/1.4.4/lang-tag-1.4.4-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_nimbusds_nimbus_jose_jwt_8_20_2.xml
+++ b/.idea/libraries/Maven__com_nimbusds_nimbus_jose_jwt_8_20_2.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.nimbusds:nimbus-jose-jwt:8.20.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/nimbus-jose-jwt/8.20.2/nimbus-jose-jwt-8.20.2.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/nimbus-jose-jwt/8.20.2/nimbus-jose-jwt-8.20.2-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/nimbus-jose-jwt/8.20.2/nimbus-jose-jwt-8.20.2-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_nimbusds_oauth2_oidc_sdk_8_36_1.xml
+++ b/.idea/libraries/Maven__com_nimbusds_oauth2_oidc_sdk_8_36_1.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.nimbusds:oauth2-oidc-sdk:8.36.1">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/oauth2-oidc-sdk/8.36.1/oauth2-oidc-sdk-8.36.1.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/oauth2-oidc-sdk/8.36.1/oauth2-oidc-sdk-8.36.1-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/nimbusds/oauth2-oidc-sdk/8.36.1/oauth2-oidc-sdk-8.36.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_sun_mail_jakarta_mail_1_6_6.xml
+++ b/.idea/libraries/Maven__com_sun_mail_jakarta_mail_1_6_6.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.sun.mail:jakarta.mail:1.6.6">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/sun/mail/jakarta.mail/1.6.6/jakarta.mail-1.6.6.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/sun/mail/jakarta.mail/1.6.6/jakarta.mail-1.6.6-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/sun/mail/jakarta.mail/1.6.6/jakarta.mail-1.6.6-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_springframework_boot_spring_boot_starter_oauth2_client_2_4_4.xml
+++ b/.idea/libraries/Maven__org_springframework_boot_spring_boot_starter_oauth2_client_2_4_4.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.springframework.boot:spring-boot-starter-oauth2-client:2.4.4">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/boot/spring-boot-starter-oauth2-client/2.4.4/spring-boot-starter-oauth2-client-2.4.4.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/boot/spring-boot-starter-oauth2-client/2.4.4/spring-boot-starter-oauth2-client-2.4.4-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/boot/spring-boot-starter-oauth2-client/2.4.4/spring-boot-starter-oauth2-client-2.4.4-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_springframework_boot_spring_boot_starter_security_2_4_4.xml
+++ b/.idea/libraries/Maven__org_springframework_boot_spring_boot_starter_security_2_4_4.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.springframework.boot:spring-boot-starter-security:2.4.4">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/boot/spring-boot-starter-security/2.4.4/spring-boot-starter-security-2.4.4.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/boot/spring-boot-starter-security/2.4.4/spring-boot-starter-security-2.4.4-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/boot/spring-boot-starter-security/2.4.4/spring-boot-starter-security-2.4.4-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_springframework_security_spring_security_config_5_4_5.xml
+++ b/.idea/libraries/Maven__org_springframework_security_spring_security_config_5_4_5.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.springframework.security:spring-security-config:5.4.5">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-config/5.4.5/spring-security-config-5.4.5.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-config/5.4.5/spring-security-config-5.4.5-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-config/5.4.5/spring-security-config-5.4.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_springframework_security_spring_security_core_5_4_5.xml
+++ b/.idea/libraries/Maven__org_springframework_security_spring_security_core_5_4_5.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.springframework.security:spring-security-core:5.4.5">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-core/5.4.5/spring-security-core-5.4.5.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-core/5.4.5/spring-security-core-5.4.5-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-core/5.4.5/spring-security-core-5.4.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_springframework_security_spring_security_oauth2_client_5_4_5.xml
+++ b/.idea/libraries/Maven__org_springframework_security_spring_security_oauth2_client_5_4_5.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.springframework.security:spring-security-oauth2-client:5.4.5">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-oauth2-client/5.4.5/spring-security-oauth2-client-5.4.5.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-oauth2-client/5.4.5/spring-security-oauth2-client-5.4.5-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-oauth2-client/5.4.5/spring-security-oauth2-client-5.4.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_springframework_security_spring_security_oauth2_core_5_4_5.xml
+++ b/.idea/libraries/Maven__org_springframework_security_spring_security_oauth2_core_5_4_5.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.springframework.security:spring-security-oauth2-core:5.4.5">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-oauth2-core/5.4.5/spring-security-oauth2-core-5.4.5.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-oauth2-core/5.4.5/spring-security-oauth2-core-5.4.5-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-oauth2-core/5.4.5/spring-security-oauth2-core-5.4.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_springframework_security_spring_security_oauth2_jose_5_4_5.xml
+++ b/.idea/libraries/Maven__org_springframework_security_spring_security_oauth2_jose_5_4_5.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.springframework.security:spring-security-oauth2-jose:5.4.5">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-oauth2-jose/5.4.5/spring-security-oauth2-jose-5.4.5.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-oauth2-jose/5.4.5/spring-security-oauth2-jose-5.4.5-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-oauth2-jose/5.4.5/spring-security-oauth2-jose-5.4.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_springframework_security_spring_security_web_5_4_5.xml
+++ b/.idea/libraries/Maven__org_springframework_security_spring_security_web_5_4_5.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.springframework.security:spring-security-web:5.4.5">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-web/5.4.5/spring-security-web-5.4.5.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-web/5.4.5/spring-security-web-5.4.5-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/springframework/security/spring-security-web/5.4.5/spring-security-web-5.4.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Description
Adds required dependencies for using OAuth2 and Spring Security in the project.

### Testing
Initially it didn't seem to quite work correctly as IntelliJ reported that the dependencies couldn't be found when hovering over them in pom.xml. If you experience this, go to File > Invalidate Caches, and hit "Invalidate and Restart".

Build and run MCITMocksApplication. If you see `o.s.s.web.DefaultSecurityFilterChain` in the output, you know that Spring Security is successfully loaded in.


### Checklist
- [x] I provided a description of the contents of this pull request.
- [ ] I've linked this pull request to an issue.
- [x] I've assigned myself as the Assignee and labelled the PR correctly.
